### PR TITLE
Add anamnese GraphQL queries

### DIFF
--- a/charm/anamnese/models.py
+++ b/charm/anamnese/models.py
@@ -28,6 +28,9 @@ class Anamnese(models.Model):
         null=True, blank=True
     )
 
+    class Meta:
+        get_latest_by = "date"
+
 class AnFormPage(AbstractEmailForm):
     content_panels = AbstractEmailForm.content_panels + [
         MultiFieldPanel(

--- a/charm/anamnese/schema.py
+++ b/charm/anamnese/schema.py
@@ -1,0 +1,64 @@
+import graphene
+
+from graphene_django.types import DjangoObjectType
+from graphql_jwt.decorators import staff_member_required, login_required
+
+from django.contrib.auth import get_user_model
+
+from .models import Anamnese
+
+class AnamneseType(DjangoObjectType):
+    class Meta:
+        model = Anamnese
+
+class Query(graphene.AbstractType):
+    # Users should not be able to see their own anamneses.
+    # myan = graphene.List(AnamneseType, token=graphene.String(required=False))
+    
+    # Returns all anamneses
+    an_all = graphene.List(
+        AnamneseType,
+        token=graphene.String(required=False)
+    )
+    
+    # Returns a single anamnese based on given id
+    an_by_id = graphene.Field(
+        AnamneseType,
+        token=graphene.String(required=False),
+        id=graphene.Int(required=True)
+    )
+    
+    # Returns all anamneses of a user with given id
+    an_by_uid = graphene.List(
+        AnamneseType,
+        token=graphene.String(required=False),
+        uid=graphene.Int(required=True)
+    )
+
+    # Returns the latest anamnese of a user with given id
+    an_latest_by_uid = graphene.Field(
+        AnamneseType,
+        token=graphene.String(required=False),
+        uid=graphene.Int(required=True)
+    )
+
+    @staff_member_required
+    def resolve_an_all(self, info, **_kwargs):
+        return Anamnese.objects.all()
+
+    @staff_member_required
+    def resolve_an_by_id(self, info, id, **_kwargs):
+        return Anamnese.objects.get(id=id)
+
+    @staff_member_required
+    def resolve_an_by_uid(self, info, uid, **_kwargs):
+        return Anamnese.objects.filter(user=get_user_model().objects.get(id=uid))
+
+    @staff_member_required
+    def resolve_an_latest_by_uid(self, info, uid, **_kwargs):
+        return Anamnese.objects.filter(user=get_user_model().objects.get(id=uid)).latest()
+
+    # @login_required
+    # def resolve_myan(self, info, **_kwargs):
+    #     user = info.context.user
+    #     return Anamnese.objects.filter(user=user)

--- a/charm/api/schema.py
+++ b/charm/api/schema.py
@@ -29,6 +29,7 @@ from .types import (  # noqa: E402
 import graphql_jwt
 
 # Register all your schemes for graphql here.
+import charm.anamnese.schema
 
 
 # api version
@@ -45,17 +46,19 @@ SettingsQueryMixin_ = SettingsQueryMixin()  # type: Any
 SnippetsQueryMixin_ = SnippetsQueryMixin()  # type: Any
 
 
-class Query(graphene.ObjectType,
-            #AuthQueryMixin_,
-            #DocumentQueryMixin_,
-            ImageQueryMixin_,
-            InfoQueryMixin_,
-            #MenusQueryMixin_,
-            PagesQueryMixin_,
-            #SettingsQueryMixin_,
-            #SnippetsQueryMixin_,
-            RelayMixin,
-            ):
+class Query(
+    charm.anamnese.schema.Query,
+    graphene.ObjectType,
+    #AuthQueryMixin_,
+    #DocumentQueryMixin_,
+    ImageQueryMixin_,
+    InfoQueryMixin_,
+    #MenusQueryMixin_,
+    PagesQueryMixin_,
+    #SettingsQueryMixin_,
+    #SnippetsQueryMixin_,
+    RelayMixin,
+    ):
     # API Version
     format = graphene.Field(String)
 

--- a/charm/user/models.py
+++ b/charm/user/models.py
@@ -116,6 +116,10 @@ class User(AbstractUser):
             # This has to be done before calling the validation function full_clean()
             User.set_password(self, str(uuid.uuid4()))
         
+        # A coach gets staff permissions
+        if User.is_coach and not User.is_staff:
+            User.is_staff == True
+
         # Seems to be checked when logging in to the Wagtail CMS.
         # Therefore raises a ValidationError when superuser is logging in as the dev SU does have an empty phone field.
         # Solution -> Skip check for superuser


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change?
 - [x] Have you tested your changes with successful results?


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)


**What is the current behavior? (link to any open issues here)**
- The anamnese model cannot be queried through GraphQL. This is essential for our project. Issue #21.


**What is the new behavior (if this is a feature change)?**
The schema.py file in the anamnese app is added. A AnamneseType is created which is based on the Anamnese model.
The schema contains four graphene types:
- List with all anamneses
- Field with one anamnese, filtered by the anamnese's id
- List with anamneses, filtered by a user id
- Field with the latest anamnese, filtered by by a user id

All queries can only be accessed with staff permissions.

The anamnese schema is then added to the API schema.py file. Also some indents are changed here.

On saving a user, it is checked now if the user is a coach, and if so, then is_staff is also set to true.