### PR TITLE
Add beautyreport GraphQL queries

### DIFF
--- a/charm/api/schema.py
+++ b/charm/api/schema.py
@@ -29,7 +29,7 @@ from .types import (  # noqa: E402
 import graphql_jwt
 
 # Register all your schemes for graphql here.
-
+import charm.beautyreport.schema
 
 # api version
 GRAPHQL_API_FORMAT = (0, 2, 0)
@@ -45,17 +45,19 @@ SettingsQueryMixin_ = SettingsQueryMixin()  # type: Any
 SnippetsQueryMixin_ = SnippetsQueryMixin()  # type: Any
 
 
-class Query(graphene.ObjectType,
-            #AuthQueryMixin_,
-            #DocumentQueryMixin_,
-            ImageQueryMixin_,
-            InfoQueryMixin_,
-            #MenusQueryMixin_,
-            PagesQueryMixin_,
-            #SettingsQueryMixin_,
-            #SnippetsQueryMixin_,
-            RelayMixin,
-            ):
+class Query(
+    charm.beautyreport.schema.Query,
+    graphene.ObjectType,
+    #AuthQueryMixin_,
+    #DocumentQueryMixin_,
+    ImageQueryMixin_,
+    InfoQueryMixin_,
+    #MenusQueryMixin_,
+    PagesQueryMixin_,
+    #SettingsQueryMixin_,
+    #SnippetsQueryMixin_,
+    RelayMixin,
+    ):
     # API Version
     format = graphene.Field(String)
 

--- a/charm/beautyreport/models.py
+++ b/charm/beautyreport/models.py
@@ -28,6 +28,9 @@ class Beautyreport(models.Model):
         null=True, blank=True
     )
 
+    class Meta:
+        get_latest_by = "date"
+
 class BrFormPage(AbstractEmailForm):
     content_panels = AbstractEmailForm.content_panels + [
         MultiFieldPanel(

--- a/charm/beautyreport/schema.py
+++ b/charm/beautyreport/schema.py
@@ -1,0 +1,78 @@
+import graphene
+
+from graphene_django.types import DjangoObjectType
+from graphql_jwt.decorators import staff_member_required, login_required
+
+from django.contrib.auth import get_user_model
+
+from .models import Beautyreport
+
+class BeautyreportType(DjangoObjectType):
+    class Meta:
+        model = Beautyreport
+
+class Query(graphene.AbstractType):
+    # Returns all beautyreports
+    br_all = graphene.List(
+        BeautyreportType,
+        token=graphene.String(required=False)
+    )
+    
+    # Returns a single beautyreport based on given id
+    br_by_id = graphene.Field(
+        BeautyreportType,
+        token=graphene.String(required=False),
+        id=graphene.Int(required=True)
+    )
+    
+    # Returns all beautyreports of a user with given id
+    br_by_uid = graphene.List(
+        BeautyreportType,
+        token=graphene.String(required=False),
+        uid=graphene.Int(required=True)
+    )
+
+    # Returns the latest beautyreport of a user with given id
+    br_latest_by_uid = graphene.Field(
+        BeautyreportType,
+        token=graphene.String(required=False),
+        uid=graphene.Int(required=True)
+    )
+
+    # Returns all beautyreports of the currently logged in user
+    br_own = graphene.List(
+        BeautyreportType,
+        token=graphene.String(required=False)
+    )
+
+    # Returns the latest beautyreport of the currently logged in user
+    br_latest_own = graphene.Field(
+        BeautyreportType,
+        token=graphene.String(required=False)
+    )
+
+    @staff_member_required
+    def resolve_ab_all(self, info, **_kwargs):
+        return Beautyreport.objects.all()
+
+    @staff_member_required
+    def resolve_ab_by_id(self, info, id, **_kwargs):
+        return Beautyreport.objects.get(id=id)
+
+    @staff_member_required
+    def resolve_ab_by_uid(self, info, uid, **_kwargs):
+        return Beautyreport.objects.filter(user=get_user_model().objects.get(id=uid))
+
+    @staff_member_required
+    def resolve_ab_latest_by_uid(self, info, uid, **_kwargs):
+        return Beautyreport.objects.filter(user=get_user_model().objects.get(id=uid)).latest()
+
+    @login_required
+    def resolve_own(self, info, **_kwargs):
+        user = info.context.user
+        return Beautyreport.objects.filter(user=user)
+
+    @login_required
+    def resolve_latest_own(self, info, **_kwargs):
+        user = info.context.user
+        return Beautyreport.objects.filter(user=user).latest()


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change?
 - [x] Have you tested your changes with successful results?


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)


**What is the current behavior? (link to any open issues here)**
- Beautyreports cannot be queried through GraphQL yet. This is essential for our project. Issue #21.


**What is the new behavior (if this is a feature change)?**
The schema.py file in the beautyreport app is added. A BeautyreportType
is created which is based on the Beautyreport model.

The schema contains six graphene types, following can be accessed only
with staff permissions:
- List with all beautyreports
- Field with one beautyreport, filtered by the beautyreport's id
- List with beautyreports, filtered by a user id
- Field with the latest beautyreport, filtered by by a user id

These can be accessed when logged in:
- List with beautyreports, filtered by the currently logged in user
- Field with the latest beautyreport, filtered by the currently logged in user

The beautyreport schema is also added to the API schema.py file.