### PR TITLE
Add extra Type for querying Coaches and Customers

### DIFF
--- a/charm/coach/schema.py
+++ b/charm/coach/schema.py
@@ -9,32 +9,36 @@ from .models import Coach
 
 class CoachType(DjangoObjectType):
     class Meta:
+        model = Coach
+
+class CoachQType(DjangoObjectType):
+    class Meta:
         model = get_user_model()
 
 class Query(graphene.AbstractType):
     # Returns all coaches
     coach_all = graphene.List(
-        CoachType,
+        CoachQType,
         token=graphene.String(required=False)
     )
     
     # Returns a single coach object based on given id
     coach_by_id = graphene.Field(
-        CoachType,
+        CoachQType,
         token=graphene.String(required=False),
         id=graphene.Int(required=True)
     )
     
     # Returns a single coach object with given phone number
     coach_by_phone = graphene.Field(
-        CoachType,
+        CoachQType,
         token=graphene.String(required=False),
         phone=graphene.String(required=True)
     )
 
     # Returns a single coach object with given username
     coach_by_name = graphene.Field(
-        CoachType,
+        CoachQType,
         token=graphene.String(required=False),
         username=graphene.String(required=True)
     )

--- a/charm/customer/schema.py
+++ b/charm/customer/schema.py
@@ -9,32 +9,36 @@ from .models import Customer
 
 class CustomerType(DjangoObjectType):
     class Meta:
+        model = Customer
+
+class CustomerQType(DjangoObjectType):
+    class Meta:
         model = get_user_model()
 
 class Query(graphene.AbstractType):
     # Returns all Customeres
     customer_all = graphene.List(
-        CustomerType,
+        CustomerQType,
         token=graphene.String(required=False)
     )
     
     # Returns a single Customer object based on given id
     customer_by_id = graphene.Field(
-        CustomerType,
+        CustomerQType,
         token=graphene.String(required=False),
         id=graphene.Int(required=True)
     )
     
     # Returns a single Customer object with given phone number
     customer_by_phone = graphene.Field(
-        CustomerType,
+        CustomerQType,
         token=graphene.String(required=False),
         phone=graphene.String(required=True)
     )
 
     # Returns a single Customer object with given username
     customer_by_name = graphene.Field(
-        CustomerType,
+        CustomerQType,
         token=graphene.String(required=False),
         username=graphene.String(required=True)
     )


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change?
 - [x] Have you tested your changes with successful results?


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)


**What is the current behavior? (link to any open issues here)**
The last pull request (#58) changed the schema model for Coaches and Customers which resulted in the User model's coach field not being able to be queried anymore. Issue #57 


**What is the new behavior (if this is a feature change)?**
This got fixed by adding a `CoachQType` and `CustomerQType` class to the respective schemas, which uses the base user model. These types are used on the query-able graphene types and exist in addition to the `CoachType` and `CustomerType` classes, which use the base User model as before.