### PR TITLE
Fix Error when saving a page with 1000+ Fields

### DIFF
--- a/charm/settings/base.py
+++ b/charm/settings/base.py
@@ -236,6 +236,7 @@ STATIC_URL = '/static/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 MEDIA_URL = '/media/'
 
+DATA_UPLOAD_MAX_NUMBER_FIELDS = 20000
 
 # Wagtail settings
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change?
 - [ ] Have you tested your changes with successful results?


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)


**What is the current behavior? (link to any open issues here)**
A TooManyFieldsSent error was thrown when a page is trying to be saved with more than 1000 individual fields, as this exceeds the `DATA_UPLOAD_MAX_NUMBER_FIELDS` setting. Issue #62 


**What is the new behavior (if this is a feature change)?**
This setting is increased to 20000 in the base.py config file.