### PR TITLE
Add requirements for lxml

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,6 +3,8 @@ wagtail>=2.5,<2.6
 wagtailfontawesome>=1.1.4,<1.2
 Pillow==4.0.0
 Jinja2==2.10.1
+libxml2>=2.9.2
+libxslt>=1.1.28
 python-docx==0.8.10
 graphene-django==2.2
 graphene_django_optimizer==0.3.6


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change?
 - [ ] Have you tested your changes with successful results?


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)


**What is the current behavior? (link to any open issues here)**
- `libxml2` and `libxslt` is missing for `lxml` to run correctly.


**What is the new behavior (if this is a feature change)?**
- `lxml` requires two requires `libxml2` and `libxslt` to be installed.
In particular:
  - `libxml2` version 2.9.2 or later and
  - `libxslt` version 1.1.27 or later.

  These are added to the base requirements file.